### PR TITLE
Fix sed build error on Linux

### DIFF
--- a/baremetal.sh
+++ b/baremetal.sh
@@ -115,7 +115,11 @@ function baremetal_setup {
 	cp src/BareMetal/api/libBareMetal.asm src/api/
 
 	# Tweak start sector since the unikernel doesn't use a hybrid disk image
-	sed -i '' 's/%define DAP_STARTSECTOR 262160/%define DAP_STARTSECTOR 16/g' src/Pure64/src/boot/bios.asm
+	if [[ "$(uname)" == "Darwin" ]]; then
+    		sed -i '' 's/%define DAP_STARTSECTOR 262160/%define DAP_STARTSECTOR 16/g' src/Pure64/src/boot/bios.asm
+	else
+    		sed -i 's/%define DAP_STARTSECTOR 262160/%define DAP_STARTSECTOR 16/g' src/Pure64/src/boot/bios.asm
+	fi
 
 	baremetal_build
 


### PR DESCRIPTION
Hello! I tried to compiling this on Gentoo and I got this error:

```
sed: can't read s/%define DAP_STARTSECTOR 262160/%define DAP_STARTSECTOR 16/g: No such file or directory
```

I looked into this error and saw you were using the macOS/BSD variant of the sed command syntax. (I didn't get sed errors when trying to compile on my MacBook Air)

I've provided a fix that switches command variants if we are running on the macOS Darwin kernel or the Linux kernel.